### PR TITLE
Remove Edge Binary

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,7 +77,3 @@ edge-runtime = []
 name = "tui-patcher-agent"
 path = "src/main.rs"
 
-[[bin]]
-name = "tui-patcher-edge"
-path = "src/edge/main.rs"
-required-features = ["edge-runtime"]


### PR DESCRIPTION
## Podsumowanie
- usunięto sekcję binarną `tui-patcher-edge` z `backend/Cargo.toml`

## Testy
- `cargo build --release` *(oczekiwane niepowodzenie – brak zgodnych wersji paczek)*
- `cargo test --workspace -- --nocapture` *(oczekiwane niepowodzenie – brak zgodnych wersji paczek)*
- `cargo fmt -- --check` *(niepowodzenie – brak pliku telemetry.rs)*
- `kubectl apply -f deploy/kubernetes --dry-run=client` *(niepowodzenie – brak komendy kubectl)*

------
https://chatgpt.com/codex/tasks/task_e_6880823a9810833097b06f8e733acd6f