### PR TITLE
Dodanie modułów telemetry i queue

### DIFF
--- a/backend/src/queue.rs
+++ b/backend/src/queue.rs
@@ -1,0 +1,139 @@
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+/// Rodzaj modyfikacji aplikacji
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PatchType {
+    Security,
+    Performance,
+    Feature,
+    Compatibility,
+    Custom(String),
+}
+
+/// Opcje dodatkowe dla zadania patchowania
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchOptions {
+    pub enable_ai_analysis: bool,
+}
+
+impl Default for PatchOptions {
+    fn default() -> Self {
+        Self { enable_ai_analysis: false }
+    }
+}
+
+/// Żądanie patchowania
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchRequest {
+    pub apk_path: String,
+    pub patch_type: PatchType,
+    pub options: PatchOptions,
+}
+
+/// Wynik patchowania
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchResult {
+    pub output_path: String,
+    pub patch_summary: String,
+    pub applied_patches: Vec<String>,
+    pub warnings: Vec<String>,
+    pub ai_analysis: Option<AiAnalysisResult>,
+}
+
+/// Poziom ryzyka wykryty przez analizę AI
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+/// Wynik analizy AI
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiAnalysisResult {
+    pub recommendations: Vec<String>,
+    pub risk_assessment: RiskLevel,
+    pub confidence_score: f64,
+}
+
+/// Status zadania w kolejce
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum JobStatus {
+    Pending,
+    Processing,
+    Completed,
+    Failed,
+}
+
+/// Zadanie patchowania przechowywane w kolejce
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchJob {
+    pub id: Uuid,
+    pub request: PatchRequest,
+    pub status: JobStatus,
+    pub result: Option<PatchResult>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Prosta kolejka zadań patchowania
+#[derive(Clone)]
+pub struct QueueManager {
+    queue: Arc<Mutex<VecDeque<PatchJob>>>,
+    pub max_concurrent_jobs: usize,
+}
+
+impl QueueManager {
+    pub fn new(max_concurrent_jobs: usize) -> Self {
+        Self { queue: Arc::new(Mutex::new(VecDeque::new())), max_concurrent_jobs }
+    }
+
+    /// Dodaje nowe zadanie do kolejki i zwraca jego identyfikator
+    pub async fn enqueue(&self, request: PatchRequest) -> Uuid {
+        let job = PatchJob {
+            id: Uuid::new_v4(),
+            request,
+            status: JobStatus::Pending,
+            result: None,
+            created_at: chrono::Utc::now(),
+        };
+        let mut guard = self.queue.lock().await;
+        guard.push_back(job.clone());
+        job.id
+    }
+
+    /// Pobiera z kolejki najstarsze zadanie
+    pub async fn dequeue(&self) -> Option<PatchJob> {
+        let mut guard = self.queue.lock().await;
+        guard.pop_front()
+    }
+
+    /// Obecna wielkość kolejki
+    pub async fn len(&self) -> usize {
+        let guard = self.queue.lock().await;
+        guard.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_enqueue_dequeue() {
+        let queue = QueueManager::new(2);
+        let req = PatchRequest {
+            apk_path: "app.apk".into(),
+            patch_type: PatchType::Security,
+            options: PatchOptions::default(),
+        };
+        let id = queue.enqueue(req.clone()).await;
+        assert_eq!(queue.len().await, 1);
+        let job = queue.dequeue().await.unwrap();
+        assert_eq!(job.id, id);
+        assert_eq!(job.request.apk_path, req.apk_path);
+    }
+}

--- a/backend/src/telemetry.rs
+++ b/backend/src/telemetry.rs
@@ -1,0 +1,43 @@
+use crate::config::TelemetryConfig;
+use opentelemetry::sdk::{trace, Resource};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Inicjalizacja systemu telemetrycznego z wykorzystaniem OpenTelemetry.
+/// Funkcja zwraca uchwyt do tracera potrzebny do poprawnego zamknięcia eksportera.
+pub async fn init_telemetry(config: &TelemetryConfig) -> anyhow::Result<opentelemetry::sdk::trace::Tracer> {
+    let exporter = opentelemetry_otlp::new_exporter()
+        .tonic()
+        .with_endpoint(&config.otel_endpoint);
+
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(exporter)
+        .with_trace_config(
+            trace::config()
+                .with_resource(Resource::new(vec![
+                    KeyValue::new("service.name", config.service_name.clone()),
+                    KeyValue::new("service.version", crate::VERSION),
+                ]))
+                .with_sampler(trace::Sampler::TraceIdRatioBased(config.sampling_ratio))
+        )
+        .with_batch_config(
+            trace::BatchConfig::default()
+                .with_max_export_batch_size(512)
+                .with_max_queue_size(2048)
+                .with_scheduled_delay(std::time::Duration::from_millis(500))
+                .with_export_timeout(std::time::Duration::from_secs(config.export_timeout_secs))
+        )
+        .install_batch(opentelemetry::runtime::Tokio)?;
+
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer.clone());
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::fmt::layer().json())
+        .with(otel_layer)
+        .init();
+
+    Ok(tracer)
+}

--- a/backend/tests/telemetry_queue.rs
+++ b/backend/tests/telemetry_queue.rs
@@ -1,0 +1,30 @@
+use tui_patcher_agent::{
+    config::TelemetryConfig,
+    queue::{PatchOptions, PatchRequest, PatchType, QueueManager},
+    telemetry::init_telemetry,
+};
+
+#[tokio::test]
+async fn init_telemetry_returns_tracer() {
+    let cfg = TelemetryConfig {
+        otel_endpoint: "http://localhost:4317".into(),
+        service_name: "test-service".into(),
+        sampling_ratio: 0.0,
+        export_timeout_secs: 1,
+    };
+    let tracer = init_telemetry(&cfg).await.expect("telemetry init");
+    opentelemetry::global::shutdown_tracer_provider();
+    let _ = tracer; // aby tracer nie był nieużywany
+}
+
+#[tokio::test]
+async fn queue_enqueue_and_len() {
+    let q = QueueManager::new(1);
+    let req = PatchRequest {
+        apk_path: "a.apk".into(),
+        patch_type: PatchType::Feature,
+        options: PatchOptions::default(),
+    };
+    q.enqueue(req).await;
+    assert_eq!(q.len().await, 1);
+}


### PR DESCRIPTION
## Podsumowanie
- implementacja `init_telemetry` zgodnie z dokumentacją OTEL
- dodanie modułu `queue` z definicjami struktur i prostą logiką
- integracja modułów w projekcie oraz testy integracyjne

## Testy
- `cargo fmt -- --check` **nie powiodło się** – brak plików niezbędnych do formatowania
- `cargo build --release` **nie powiodło się** – problem z zależnością `axum-otel`
- `cargo test --workspace -- --nocapture` **nie powiodło się** – problem z zależnością `axum-otel`


------
https://chatgpt.com/codex/tasks/task_e_6880fa760594833084d07532f5247db0