### PR TITLE
Dodano README i instrukcje builda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# TUI-Patcher-Agent
+
+Ten projekt zawiera mikroserwis do inteligentnego łatania aplikacji Android z obsługą telemetrii oraz prosty interfejs webowy. Dokumentacja techniczna znajduje się w katalogu `docs/`.
+
+## Kompilacja backendu
+
+```bash
+cd backend
+cargo build --release
+```
+
+## Testy backendu
+
+```bash
+cd backend
+cargo test --workspace -- --nocapture
+```
+
+## Uruchomienie frontendu
+
+```bash
+cd frontend
+python3 -m http.server 8080
+# otwórz http://localhost:8080 w przeglądarce
+```
+
+## Wdrożenie przez Docker Compose
+
+```bash
+docker compose up -d --build
+docker compose ps
+docker compose logs -f
+```
+
+## Dokumentacja
+
+- [Architektura](docs/ARCHITECTURE.md)
+- [Wdrożenie na Edge](docs/EDGE_GUIDE.md)
+- [Obserwowalność](docs/OBSERVABILITY.md)
+- [Rozszerzona dokumentacja](docs/README.md)
+


### PR DESCRIPTION
## Podsumowanie
- dodano polski README w katalogu glownym
- opisano kompilacje i testy backendu
- instrukcja uruchomienia frontendu oraz wdrozenia Docker Compose
- linki do dokumentacji w `docs/`

## Testy
- `cargo build --release` (blad wersji axum-otel)
- `cargo test --workspace -- --nocapture` (blad wersji axum-otel)
- `cargo fmt -- --check` (brak plikow/modulow)


------
https://chatgpt.com/codex/tasks/task_e_6880fa7b96408330b2787c6ff2035a1e