### PR TITLE
Usunięcie bina edge z Cargo

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,7 +77,3 @@ edge-runtime = []
 name = "tui-patcher-agent"
 path = "src/main.rs"
 
-[[bin]]
-name = "tui-patcher-edge"
-path = "src/edge/main.rs"
-required-features = ["edge-runtime"]


### PR DESCRIPTION
## Podsumowanie
- usunięto definicję bina `tui-patcher-edge` z `Cargo.toml`

## Testy
- `cargo fmt -- --check` *(błąd: nie odnaleziono modułu `telemetry`)*
- `cargo build --release` *(błąd zależności: nie znaleziono wersji `axum-otel`)*
- `cargo test` *(taki sam błąd zależności)*

------
https://chatgpt.com/codex/tasks/task_e_6880fa926b048330acc774f2f5b7f7ec